### PR TITLE
chore(docker): Fix dockerfile for distroless runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ RUN set -eux; \
     -o /app/out
 
 ###############################################
+# Getting libicu stage
+###############################################
+FROM mcr.microsoft.com/dotnet/runtime-deps:9.0 AS icu
+
+###############################################
 # Runtime stage
 ###############################################
 FROM gcr.io/distroless/cc-debian12:nonroot AS final
@@ -53,8 +58,10 @@ WORKDIR /app
 
 # Kestrel を 8080 で待ち受け
 ENV ASPNETCORE_URLS=http://0.0.0.0:8080
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 EXPOSE 8080
+
+# libicu をコピー
+COPY --from=icu /usr/lib/*-linux-gnu/libicu*.so.* /usr/lib/
 
 # ビルド成果物をコピー
 COPY --from=build /app/out/Man10BankService /app/Man10BankService


### PR DESCRIPTION
dotnetランタイムを必要しない、シングルバイナリ化をするようにしました。
(`SYSTEM_GLOBALIZATION`が`INVARIANT`で固定されています。たぶん用途的に大丈夫だと思うのですが、これで問題がありそうならlibicuをFINALステージに含めればOK)