### PR TITLE
feat: スケジューラ起動可否をScheduler:Enabledで切替可能に（複数インスタンス対応）

### DIFF
--- a/Man10BankService/Program.cs
+++ b/Man10BankService/Program.cs
@@ -100,11 +100,24 @@ builder.Services.AddSingleton<Man10BankService.Services.LoanService>();
 builder.Services.AddSingleton<Man10BankService.Services.EstateService>();
 builder.Services.AddSingleton<Man10BankService.Services.ServerEstateService>();
 
-// スケジューラ(BackgroundService)を登録
-builder.Services.AddHostedService<Man10BankService.Services.ServerLoanSchedulerService>();
-builder.Services.AddHostedService<Man10BankService.Services.ServerEstateSchedulerService>();
+// スケジューラ(BackgroundService)を登録。
+// 複数インスタンスを並列起動すると各インスタンスでスケジューラが二重実行され、
+// 日次利息の多重課金・週次返済の多重引落し・スナップショット重複INSERTが起きうる。
+// そのため Scheduler:Enabled で起動可否を切り替える(既定 true: 単一インスタンス運用と互換)。
+// 水平スケール時はリーダー1台のみ true とし、他インスタンスは Scheduler__Enabled=false で起動すること。
+var schedulerEnabled = builder.Configuration.GetValue("Scheduler:Enabled", true);
+if (schedulerEnabled)
+{
+    builder.Services.AddHostedService<Man10BankService.Services.ServerLoanSchedulerService>();
+    builder.Services.AddHostedService<Man10BankService.Services.ServerEstateSchedulerService>();
+}
 
 var app = builder.Build();
+
+// 起動したインスタンスがスケジューラ担当かどうかをログに残す(運用時の取り違え防止)。
+app.Logger.LogInformation(
+    "スケジューラ(サーバーローン日次利息/週次返済・資産スナップショット): {State}",
+    schedulerEnabled ? "有効" : "無効");
 
 using (var scope = app.Services.CreateScope())
 {

--- a/Man10BankService/appsettings.json
+++ b/Man10BankService/appsettings.json
@@ -26,6 +26,9 @@
     "Password": "",
     "TreatTinyAsBoolean": true
   },
+  "Scheduler": {
+    "Enabled": true
+  },
   "ServerLoan": {
     "DailyInterestRate": 0.001,
     "MinAmount": 100000,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,10 @@ services:
       #   Auth__ApiKeys__0__Key: "<長いランダム文字列>"
       #   Auth__ApiKeys__0__Name: "man10bank-plugin"
       #   Auth__ApiKeys__0__Scopes__0: "admin"
+      # スケジューラ（日次利息・週次返済・資産スナップショット）の起動可否。既定 true。
+      # 複数インスタンスを並列起動する場合は、リーダー1台のみ true（未指定でも可）にし、
+      # 残りのインスタンスでは二重実行防止のため必ず false を指定すること:
+      #   Scheduler__Enabled: "false"
     ports:
       - "8080:8080"
 


### PR DESCRIPTION
## 目的
本番でポートを変えて複数インスタンスを並列起動できるようにするための前提整備。

現状、スケジューラ（`ServerLoanSchedulerService` / `ServerEstateSchedulerService`）は全インスタンスで無条件に起動するため、複数インスタンスを並列起動すると以下が**インスタンス間で二重実行**される。冪等性は単一プロセスの再起動を前提に設計されており、同時実行は想定外。

- サーバーローン日次利息: 確認（`HasInterestLogOnDateAsync`）→加算が非アトミックで、ユニーク制約も無いため**多重課金**しうる。
- サーバーローン週次返済: インメモリ変数のみのガードのため、別プロセスでは抑止されず**多重引落し**。
- サーバー資産スナップショット: 確認→INSERT が非アトミックで**重複INSERT**。

## 変更内容
- `Scheduler:Enabled`（既定 `true`）で2つのスケジューラの起動可否を切り替え可能にした（`Program.cs`）。
- 起動時に「スケジューラ: 有効/無効」をログ出力し、運用時の取り違えを防ぐ。
- `appsettings.json` に `Scheduler.Enabled` を追加。
- `docker-compose.yml` に複数インスタンス時の `Scheduler__Enabled: "false"` 運用例コメントを追記。

## 運用
- 既定 `true` のため、**既存の単一インスタンス運用は無変更で従来通り**動作する。
- 水平スケール時は**リーダー1台のみ有効**（未指定でも可）、残りは `Scheduler__Enabled=false` で起動する。
- APIリクエスト処理（入出金・送金・借入・返済）はMySQLの行ロック（`FOR UPDATE`）で直列化されており、複数インスタンスでも残高は安全。本PRはスケジューラの二重実行のみを切り分けるもの。

## テストノート
- `dotnet build -c Release`: 0警告 / 0エラー。
- 手動確認（推奨）: `Scheduler__Enabled=false` で起動 → 起動ログが「無効」になり、スケジューラの定期処理が走らないこと。`true`（または未指定）で従来通り動くこと。

## 補足（フォローアップ候補・本PR対象外）
フラグ設定ミスへの保険として、利息ログ `(uuid, date)` ・スナップショット `(hour)` のユニーク制約付与、週次返済の冪等化を別途行うと堅牢。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
